### PR TITLE
Remove allowBackup attribute from AndroidManifest

### DIFF
--- a/android-patternview/src/main/AndroidManifest.xml
+++ b/android-patternview/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.eftimoff.mylibrary">
 
-    <application android:allowBackup="true">
-
-    </application>
+    <application />
 
 </manifest>


### PR DESCRIPTION
This should not be specified in a library.
I got this build error because my app specifies allowBackup=false:

```
Execution failed for task ':OpenKeychain:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:73:9
        is also present at com.eftimoff:android-patternview:1.0.0:11:18 value=(true)
        Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:71:5 to override
```
