### PR TITLE
Fixed a crash when rotating the screen due to an empty pattern string.

### DIFF
--- a/android-patternview/src/main/java/com/eftimoff/patternview/utils/CellUtils.java
+++ b/android-patternview/src/main/java/com/eftimoff/patternview/utils/CellUtils.java
@@ -36,10 +36,14 @@ public class CellUtils {
      */
     public static List<Cell> stringToPattern(final String string, final CellManager cellManager) {
         final List<Cell> result = new ArrayList<>();
+
+        if(string.isEmpty()) {
+            return result;
+        }
+
         final String[] allCells = string.split("&");
-        final int length = allCells.length;
-        for (int i = 0; i < length; i++) {
-            final String[] rowAndColumn = allCells[i].split("-");
+        for (String allCell : allCells) {
+            final String[] rowAndColumn = allCell.split("-");
             final int row = Integer.valueOf(rowAndColumn[0]);
             final int column = Integer.valueOf(rowAndColumn[1]);
             final Cell cell = cellManager.get(row, column);


### PR DESCRIPTION
The stringToPattern method attempts to convert the empty string to an integer which caused the exception.
